### PR TITLE
Fix footer_languageselect using wrong redirect variable

### DIFF
--- a/Curves UI-alpha-theme.xml
+++ b/Curves UI-alpha-theme.xml
@@ -14700,7 +14700,7 @@ Post.dropZone.parents().eq(1).hide();
 
 
 <form method="POST" action="{$lang_redirect_url['location']}" id="lang_select">
-	{$theme_redirect_url['form_html']}
+	{$lang_redirect_url['form_html']}
 	<input type="hidden" name="my_post_key" value="{$mybb->post_code}" />
 	<div class="row g-1">
 	<div class="col-auto align-self-center">


### PR DESCRIPTION
Noticed that switching the language via the language selection footer results in an error (e.g. redirects to /showthread.php instead of the specific thread).

Compared this against the default template and noticed `footer_languageselect` should use `$lang_redirect_url['form_html']` for the redirect URL rather than the theme version of this variable.
